### PR TITLE
feat: add explanatory comments to tsconfig.build.json

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
+  // The root project has no sources of its own. By setting `files` to an empty
+  // list, TS won't automatically include all sources below root (the default).
   "files": [],
-  "references": [{ "path": "packages/x-core" }, { "path": "packages/x-cli" }]
+  // Building this project will build all of the following:
+  "references": [
+    { "path": "packages/x-core" },
+    { "path": "packages/x-cli" }
+  ]
 }


### PR DESCRIPTION
It may not be immediately evident what the settings in `tsconfig.build.json` are for. Given the pedagogical purpose of this repo, this change adds inline comments to clarify the purpose of the settings.